### PR TITLE
Add CDK infrastructure and update workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,26 +6,30 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-east-1
     steps:
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
       - name: Build and push Docker images
         run: |
-          docker build -f Dockerfile.frontend -t $ECR_REGISTRY/frontend:$GITHUB_SHA .
-          docker build -f Dockerfile.graphql -t $ECR_REGISTRY/graphql:$GITHUB_SHA .
-          docker build -f Dockerfile.rest -t $ECR_REGISTRY/rest:$GITHUB_SHA .
-          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REGISTRY
-          docker push $ECR_REGISTRY/frontend:$GITHUB_SHA
-          docker push $ECR_REGISTRY/graphql:$GITHUB_SHA
-          docker push $ECR_REGISTRY/rest:$GITHUB_SHA
-      - name: Deploy to ECS
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ecs-task-def.json
-          service: job-tracker
-          cluster: job-tracker-cluster
-          wait-for-service-stability: true
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          ECR_REGISTRY="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+          docker build -f Dockerfile.frontend -t $ECR_REGISTRY/job-tracker-frontend:latest .
+          docker build -f Dockerfile.graphql -t $ECR_REGISTRY/job-tracker-graphql:latest .
+          docker build -f Dockerfile.rest -t $ECR_REGISTRY/job-tracker-rest:latest .
+          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
+          docker push $ECR_REGISTRY/job-tracker-frontend:latest
+          docker push $ECR_REGISTRY/job-tracker-graphql:latest
+          docker push $ECR_REGISTRY/job-tracker-rest:latest
+      - name: Deploy CDK stack
+        run: |
+          npm install -g aws-cdk
+          cd cdk
+          npm install
+          npx cdk synth
+          npx cdk deploy --require-approval=never

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,0 +1,9 @@
+# Infrastructure
+
+This CDK app defines the AWS infrastructure for the Job Tracker project.
+
+It creates a VPC, ECS cluster, ECR repositories, Fargate services for the
+frontend, GraphQL server and REST API, and Cognito user/identity pools.
+
+Run `npx cdk deploy` from this directory to deploy the stack. The stack outputs
+include the service URLs and Cognito identifiers used by the application.

--- a/cdk/bin/job-tracker.ts
+++ b/cdk/bin/job-tracker.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { JobTrackerStack } from '../lib/job-tracker-stack.js';
+
+const app = new cdk.App();
+new JobTrackerStack(app, 'JobTrackerStack');

--- a/cdk/lib/job-tracker-stack.ts
+++ b/cdk/lib/job-tracker-stack.ts
@@ -1,0 +1,134 @@
+import { Stack, StackProps, Duration, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+export class JobTrackerStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    // VPC and ECS Cluster
+    const vpc = new ec2.Vpc(this, 'Vpc', { maxAzs: 2 });
+    const cluster = new ecs.Cluster(this, 'Cluster', { vpc });
+
+    // ECR repositories
+    const frontendRepo = new ecr.Repository(this, 'FrontendRepo', {
+      repositoryName: 'job-tracker-frontend',
+    });
+    const graphqlRepo = new ecr.Repository(this, 'GraphqlRepo', {
+      repositoryName: 'job-tracker-graphql',
+    });
+    const restRepo = new ecr.Repository(this, 'RestRepo', {
+      repositoryName: 'job-tracker-rest',
+    });
+
+    // Fargate services
+    const frontendService = new ecsPatterns.ApplicationLoadBalancedFargateService(
+      this,
+      'FrontendService',
+      {
+        cluster,
+        cpu: 256,
+        desiredCount: 1,
+        memoryLimitMiB: 512,
+        taskImageOptions: {
+          image: ecs.ContainerImage.fromEcrRepository(frontendRepo, 'latest'),
+          containerPort: 3000,
+        },
+        publicLoadBalancer: true,
+      },
+    );
+
+    const graphqlService = new ecsPatterns.ApplicationLoadBalancedFargateService(
+      this,
+      'GraphqlService',
+      {
+        cluster,
+        cpu: 256,
+        desiredCount: 1,
+        memoryLimitMiB: 512,
+        taskImageOptions: {
+          image: ecs.ContainerImage.fromEcrRepository(graphqlRepo, 'latest'),
+          containerPort: 4000,
+        },
+        publicLoadBalancer: true,
+      },
+    );
+
+    const restService = new ecsPatterns.ApplicationLoadBalancedFargateService(
+      this,
+      'RestService',
+      {
+        cluster,
+        cpu: 256,
+        desiredCount: 1,
+        memoryLimitMiB: 512,
+        taskImageOptions: {
+          image: ecs.ContainerImage.fromEcrRepository(restRepo, 'latest'),
+          containerPort: 3001,
+        },
+        publicLoadBalancer: true,
+      },
+    );
+
+    // Cognito User Pool & Identity Pool
+    const userPool = new cognito.UserPool(this, 'UserPool', {
+      selfSignUpEnabled: true,
+      signInAliases: { email: true },
+    });
+
+    const userPoolClient = new cognito.UserPoolClient(this, 'UserPoolClient', {
+      userPool,
+    });
+
+    const identityPool = new cognito.CfnIdentityPool(this, 'IdentityPool', {
+      allowUnauthenticatedIdentities: false,
+      cognitoIdentityProviders: [
+        {
+          clientId: userPoolClient.userPoolClientId,
+          providerName: userPool.userPoolProviderName,
+        },
+      ],
+    });
+
+    const authenticatedRole = new iam.Role(this, 'CognitoDefaultAuthRole', {
+      assumedBy: new iam.FederatedPrincipal(
+        'cognito-identity.amazonaws.com',
+        {
+          StringEquals: {
+            'cognito-identity.amazonaws.com:aud': identityPool.ref,
+          },
+          'ForAnyValue:StringLike': {
+            'cognito-identity.amazonaws.com:amr': 'authenticated',
+          },
+        },
+        'sts:AssumeRoleWithWebIdentity',
+      ),
+    });
+
+    new cognito.CfnIdentityPoolRoleAttachment(this, 'DefaultAuthRoleAttachment', {
+      identityPoolId: identityPool.ref,
+      roles: { authenticated: authenticatedRole.roleArn },
+    });
+
+    // Outputs
+    new CfnOutput(this, 'FrontendUrl', {
+      value: `http://${frontendService.loadBalancer.loadBalancerDnsName}`,
+    });
+    new CfnOutput(this, 'GraphqlUrl', {
+      value: `http://${graphqlService.loadBalancer.loadBalancerDnsName}`,
+    });
+    new CfnOutput(this, 'RestUrl', {
+      value: `http://${restService.loadBalancer.loadBalancerDnsName}`,
+    });
+    new CfnOutput(this, 'UserPoolId', { value: userPool.userPoolId });
+    new CfnOutput(this, 'UserPoolClientId', {
+      value: userPoolClient.userPoolClientId,
+    });
+    new CfnOutput(this, 'IdentityPoolId', { value: identityPool.ref });
+  }
+}

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cdk",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["lib/**/*.ts", "bin/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add new CDK app defining VPC, ECS Fargate services, ECR repos, and Cognito
- output service URLs and Cognito ids for use by apps
- update GitHub Actions workflow to deploy the CDK stack instead of ECS task definition

## Testing
- `npm --version`
- `echo no tests`